### PR TITLE
Use `sqlite-diffable` as a Python module

### DIFF
--- a/sqlite_diffable/__init__.py
+++ b/sqlite_diffable/__init__.py
@@ -1,0 +1,24 @@
+import sqlite_diffable.cli
+import click
+
+def load(dbpath, directory, replace=False):
+    params = [dbpath, directory]
+    if replace:
+      params.append('--replace')
+    try:
+        sqlite_diffable.cli.load(params, standalone_mode=False)
+    except click.exceptions.ClickException as e:
+       print("Use the replace parameter to over-write existing tables")
+       # raise(e)
+
+def dump(dbpath, output, tables=[], all=False):
+    params = [dbpath, output]
+    if tables:
+       params += tables
+    if all:
+       params.append('--all')
+    try:
+        sqlite_diffable.cli.dump(params, standalone_mode=False)
+    except click.exceptions.ClickException as e:
+       print("You must set all to True or specify a list of tables")
+       # raise(e)

--- a/sqlite_diffable/__init__.py
+++ b/sqlite_diffable/__init__.py
@@ -22,3 +22,11 @@ def dump(dbpath, output, tables=[], all=False):
     except click.exceptions.ClickException as e:
        print("You must set all to True or specify a list of tables")
        # raise(e)
+
+def objects(filepath, output='', array=False):
+    params = [filepath]
+    if output:
+       params += ['--output', output]
+    if array:
+       params.append('--array')
+    sqlite_diffable.cli.objects(params, standalone_mode=False)

--- a/sqlite_diffable/__init__.py
+++ b/sqlite_diffable/__init__.py
@@ -9,7 +9,8 @@ def load(dbpath, directory, replace=False):
         sqlite_diffable.cli.load(params, standalone_mode=False)
     except click.exceptions.ClickException as e:
        print("Use the replace parameter to over-write existing tables")
-       # raise(e)
+       return False
+    return True
 
 def dump(dbpath, output, tables=[], all=False):
     params = [dbpath, output]
@@ -20,8 +21,9 @@ def dump(dbpath, output, tables=[], all=False):
     try:
         sqlite_diffable.cli.dump(params, standalone_mode=False)
     except click.exceptions.ClickException as e:
-       print("You must set all to True or specify a list of tables")
-       # raise(e)
+        print("You must set all to True or specify a list of tables")
+        return False
+    return True
 
 def objects(filepath, output='', array=False):
     params = [filepath]

--- a/tests/test_dump_module.py
+++ b/tests/test_dump_module.py
@@ -1,0 +1,61 @@
+import sqlite_diffable
+import json
+import sqlite_utils
+
+def test_dump_module(one_table_db, tmpdir):
+    output_dir = tmpdir / "out"
+    sqlite_diffable.dump(one_table_db, str(output_dir), tables=["one_table"])
+    
+    ndjson = output_dir / "one_table.ndjson"
+    metadata = output_dir / "one_table.metadata.json"
+    assert ndjson.exists()
+    assert metadata.exists()
+    assert [[1, "Stacey"], [2, "Tilda"], [3, "Bartek"]] == [
+        json.loads(line) for line in ndjson.open()
+    ]
+    assert {
+        "name": "one_table",
+        "columns": ["id", "name"],
+        "schema": "CREATE TABLE [one_table] (\n   [id] INTEGER PRIMARY KEY,\n   [name] TEXT\n)",
+    } == json.load(metadata)
+
+def test_dump_all_module(two_tables_db, tmpdir):
+    output_dir = tmpdir / "out"
+    sqlite_diffable.dump(two_tables_db, str(output_dir), all=True)
+    assert (output_dir / "one_table.ndjson").exists()
+    assert (output_dir / "one_table.metadata.json").exists()
+    assert (output_dir / "second_table.ndjson").exists()
+    assert (output_dir / "second_table.metadata.json").exists()
+
+def test_load(two_tables_db, tmpdir):
+    output_dir = tmpdir / "out"
+    restore_db = str(tmpdir / "restore.db")
+    sqlite_diffable.dump(two_tables_db, str(output_dir), all=True)
+
+    sqlite_diffable.load(restore_db, str(output_dir))
+
+    db = sqlite_utils.Database(restore_db)
+    assert set(db.table_names()) == {"second_table", "one_table"}
+    assert list(db["one_table"].rows) == [
+        {"id": 1, "name": "Stacey"},
+        {"id": 2, "name": "Tilda"},
+        {"id": 3, "name": "Bartek"},
+    ]
+    assert list(db["second_table"].rows) == [
+        {"id": 1, "name": "Cleo"},
+    ]
+
+    # Running load a second time should error 
+    result = sqlite_diffable.load(restore_db, str(output_dir))
+    assert not result
+
+    (output_dir / "one_table.ndjson").write_text(
+        '[1, "Stacey"]\n[2, "Tilda"]\n', "utf-8"
+    )
+    result = sqlite_diffable.load(restore_db, str(output_dir), replace=True)
+    assert result
+    assert list(db["one_table"].rows) == [
+        {"id": 1, "name": "Stacey"},
+        {"id": 2, "name": "Tilda"},
+    ]    
+


### PR DESCRIPTION
The pull list of changes are described in Issue #9, the summary can be found below:

- Created wrapper functions for `load`, `dump and `object` using click and sample code from [this StackOverflow post](https://stackoverflow.com/questions/48619517/call-a-click-command-from-code/54259095#54259095).

- Added tests for dumping  one and two tables, and loading two tables. 