### PR TITLE
Add an --exclude option to the dump command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ To dump out every table in that database, use `--all`:
 
     sqlite-diffable dump fixtures.db dump/ --all
 
+To dump all table except some specific ones, use `--exclude` one or more times:
+
+    sqlite-diffable dump fixtures.db dump/ --all --exclude unwanted_first_table --exclude unwanted_second_table
+
 ## Loading a database
 
 To load a previously dumped database, run the following:

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -37,6 +37,18 @@ def test_dump_all(two_tables_db, tmpdir):
     assert (output_dir / "second_table.metadata.json").exists()
 
 
+def test_dump_exclude(two_tables_db, tmpdir):
+    output_dir = tmpdir / "out"
+    result = CliRunner().invoke(
+        cli.cli, ["dump", two_tables_db, str(output_dir), "--all", "--exclude", "second_table"]
+    )
+    assert result.exit_code == 0, result.output
+    assert (output_dir / "one_table.ndjson").exists()
+    assert (output_dir / "one_table.metadata.json").exists()
+    assert not (output_dir / "second_table.ndjson").exists()
+    assert not (output_dir / "second_table.metadata.json").exists()
+
+
 def test_load(two_tables_db, tmpdir):
     output_dir = tmpdir / "out"
     restore_db = tmpdir / "restore.db"


### PR DESCRIPTION
First of all thanks for this tool!

I find myself wanting to dump all tables in a database with the exclusions of a few. 
For the curious about more details I would like to dump all the tables of a database with the exclusion of the tables automatically created by the FTS module https://www.sqlite.org/fts5.html#fts5_data_structures (%_idx, %_data, etc tables); if I don't exclude these tables when making a full dump of a database, it would then error on re-load because these tables are automatically created. The specific use-case I tried this on was with the logs database used by https://github.com/simonw/llm, see https://github.com/simonw/llm/issues/680 for more details.

It is already possible to explicit only dump some tables by listing their names.
However as databases evolve, rather than having to keep track of new tables to add to the list of those to export, I think it would be convenient to just request a dump of all tables minus a few unwanted ones.

This PR introduces the `--exclude` parameter that can be used to exclude specific tables. 

Note: The same can be achieved with a combination of `sqlite-utils` invocations to list all tables and remove the unwanted ones, but I think directly adding the `--exclude` parameter helps with the ergonomics of this tool for minimal added complexity
Note2: I thought about implementing a more flexible logic for the new parameter, for example by providing a single comma-separated value instead of having to use multiple `--exclude`s  or even implementing it as an opt-out regex, but ultimately decided against the unnecessary additional complexity.

Happy to hear any feedback